### PR TITLE
Fix kibana avec un type qui a 2 valeur

### DIFF
--- a/Vera/Vera/PackageInfo.xml
+++ b/Vera/Vera/PackageInfo.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Package xmlns="http://schemas.myconstellation.io/Constellation/1.8/PackageManifest"
          Name="Vera"
-         Version="1.6"
          Author="Sebastien Warin & contribs"
+         Version="1.6.1"
          Icon="vera.png"
          URL="http://sebastien.warin.fr"
          Description="Connect your Vera to Constellation"

--- a/Vera/Vera/Program.cs
+++ b/Vera/Vera/Program.cs
@@ -74,7 +74,7 @@ namespace Vera
                     {
                         DataVersion = e.DataVersion,
                         LoadTime = e.LoadTime,
-                        State = vera.CurrentState.ToString(),
+                        State = vera.CurrentState,
                         Comment = vera.CurrentComment,
                         Model = vera.Model,
                         SerialNumber = vera.SerialNumber,

--- a/Vera/Vera/StateObjects.cs
+++ b/Vera/Vera/StateObjects.cs
@@ -49,7 +49,7 @@ namespace VeraNet
         /// <value>
         /// The Vera state.
         /// </value>
-        public string State { get; set; }
+        public VeraNet.Objects.VeraState State { get; set; }
         /// <summary>
         /// Gets or sets the Vera comment.
         /// </summary>


### PR DESCRIPTION
La variable "State" peux avoir 2 type dans kibana (Number et String). J'ai converti le String en number pour réglé un problème de cast exception dans kibana.