### PR TITLE
return success status when seeing an episode

### DIFF
--- a/BetaSeries/BetaSeries/PackageInfo.xml
+++ b/BetaSeries/BetaSeries/PackageInfo.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Package xmlns="http://schemas.myconstellation.io/Constellation/1.8/PackageManifest"
          Name="BetaSeries"
-         Version="1.0.0"
+         Version="1.1.0"
          Author="Romain ODDONE"
          URL="https://github.com/roddone"
          Description="Get your favourite shows planning with BetaSeries through Constellation"

--- a/BetaSeries/BetaSeries/Program.cs
+++ b/BetaSeries/BetaSeries/Program.cs
@@ -121,11 +121,22 @@ namespace BetaSeries
         /// <param name="bulk">Mark all previous episodes as seen (default: true)</param>
         /// <returns></returns>
         [MessageCallback]
-        public void MarkEpisodeAsSeen(string id, bool bulk = true)
+        public bool MarkEpisodeAsSeen(string id, bool bulk = true)
         {
-            Net.Models.EPISODES.Watched.Post(new { id, bulk }).Wait();
+            try
+            {
+                var response = Net.Models.EPISODES.Watched.Post(new { id, bulk }).Result;
 
-            PackageHost.WriteInfo($"Episode '{id}' marked as seen.");
+                PackageHost.WriteInfo($"Episode '{id}' marked as seen.");
+
+                return response != null && response.errors.Count == 0;
+            }
+            catch(Exception ex)
+            {
+                PackageHost.WriteError($"An error occurred while seeing episode '{id}' : {ex.Message}");
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
L'API BetaSeries foire de temps à autres, du coup j'ai préféré ajouter un booléen pour indiquer le succès de l'action.
Cela permet également de rendre la méthode appelable via une Saga et effectuer d'autres actions de façon synchrones. 