### PR TITLE
Fix waze encoding on http request.

### DIFF
--- a/Waze/Waze/PackageInfo.xml
+++ b/Waze/Waze/PackageInfo.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Package xmlns="http://schemas.myconstellation.io/Constellation/1.8/PackageManifest"
          Name="Waze"
-         Version="1.1.0"
+         Version="1.1.1"
          Author="Hydro, Romain ODDONE"
          Icon="Waze.png"
          URL="http://www.myconstellation.io"

--- a/Waze/Waze/Program.cs
+++ b/Waze/Waze/Program.cs
@@ -55,6 +55,8 @@ namespace Waze
                 webClient.Headers.Add("user-agent", "Mozilla/5.0");
                 //referer, required to avoid a 403 HTTP Respopnse from waze
                 webClient.Headers.Add("Referer", "https://www.waze.com");
+                //force encoding in order to avoid accents problems
+                webClient.Encoding = System.Text.Encoding.UTF8;
 
                 string result = webClient.DownloadString(addressUrl);
                 response = JsonConvert.DeserializeObject<RoutingRequestResponse>(result, this.jsonSerializerSettings);


### PR DESCRIPTION
Fix encoding error on http request causing accents to be badly displayed.